### PR TITLE
Fix accessibility audit

### DIFF
--- a/lib/accessibility.js
+++ b/lib/accessibility.js
@@ -2,7 +2,7 @@ const Eval = require('./eval')
 
 exports.audit = () => {
   return Eval.execute(function () {
-    const {axs} = window.__devtron // defined in browser-globals.js
+    const axs = require('accessibility-developer-tools')
     const config = new axs.AuditConfiguration({showUnsupportedRulesWarning: false})
     const results = axs.Audit.run(config)
 

--- a/lib/browser-globals.js
+++ b/lib/browser-globals.js
@@ -2,7 +2,5 @@
 // (via the content_scripts definition in manifest.json)
 //
 // It is generated via `npm run-script prepublish`
-const axs = require('accessibility-developer-tools')
 
 window.__devtron = window.__devtron || {}
-window.__devtron.axs = axs


### PR DESCRIPTION
Fix #138

`window.__devtron.axs = axs` seems only be applied to the devtron iframe, not the "top" window.

Probably related to this policy: https://developer.chrome.com/extensions/content_scripts#isolated_world

> Isolated worlds do not allow for content scripts, the extension, and the web page to access any variables or functions created by the others. This also gives content scripts the ability to enable functionality that should not be accessible to the web page.

