### PR TITLE
fix:adapt chrome-extension rules

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,11 @@
 {
   "name": "devtron",
   "version": "1.0",
+  "manifest_version": 2,
   "devtools_page": "static/devtron.html",
   "content_scripts": [
     {
-      "matches": ["*"],
+      "matches": ["https://*/*"],
       "js": ["out/browser-globals.js"]
     }
   ]

--- a/static/createDevtool.js
+++ b/static/createDevtool.js
@@ -1,0 +1,1 @@
+chrome.devtools.panels.create('Devtron', 'devtron.png', 'static/index.html')

--- a/static/devtron.html
+++ b/static/devtron.html
@@ -3,8 +3,6 @@
   <head>
     <meta charset="utf-8">
     <title>devtron</title>
-    <script>
-      chrome.devtools.panels.create('Devtron', 'devtron.png', 'static/index.html')
-    </script>
+    <script src="./createDevtool.js"></script>
   </head>
 </html>


### PR DESCRIPTION
adapt chrome-extension rules so that devtron can be installed successfully
see https://github.com/electron-userland/devtron/issues/211