### PR TITLE
fix: Cannot read property 'BrowserWindow' of undefined issue when ins…

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,28 +1,30 @@
-const electron = require('electron')
+const { session } = require('electron')
 
 exports.install = () => {
+  const ses = session.defaultSession
+
   if (process.type === 'renderer') {
-    console.log(`Installing Devtron from ${__dirname}`)
-    if (electron.remote.BrowserWindow.getDevToolsExtensions &&
-        electron.remote.BrowserWindow.getDevToolsExtensions().devtron) return true
-    return electron.remote.BrowserWindow.addDevToolsExtension(__dirname)
+    console.log(`Installing [renderer] Devtron from ${__dirname}`)
+    if (ses.getAllExtensions && ses.getAllExtensions().devtron) return true
+    return ses.loadExtension(__dirname)
   } else if (process.type === 'browser') {
-    console.log(`Installing Devtron from ${__dirname}`)
-    if (electron.BrowserWindow.getDevToolsExtensions &&
-        electron.BrowserWindow.getDevToolsExtensions().devtron) return true
-    return electron.BrowserWindow.addDevToolsExtension(__dirname)
+    console.log(`Installing [browser] Devtron from ${__dirname}`)
+    if (ses.getAllExtensions && ses.getAllExtensions().devtron) return true
+    return ses.loadExtension(__dirname)
   } else {
     throw new Error('Devtron can only be installed from an Electron process.')
   }
 }
 
 exports.uninstall = () => {
+  const ses = session.defaultSession
+
   if (process.type === 'renderer') {
-    console.log(`Uninstalling Devtron from ${__dirname}`)
-    return electron.remote.BrowserWindow.removeDevToolsExtension('devtron')
+    console.log(`Uninstalling [renderer] Devtron from ${__dirname}`)
+    return ses.removeExtension('devtron')
   } else if (process.type === 'browser') {
-    console.log(`Uninstalling Devtron from ${__dirname}`)
-    return electron.BrowserWindow.removeDevToolsExtension('devtron')
+    console.log(`Uninstalling [browser] Devtron from ${__dirname}`)
+    return ses.removeExtension('devtron')
   } else {
     throw new Error('Devtron can only be uninstalled from an Electron process.')
   }


### PR DESCRIPTION
…tall devtron

As the methods of: electron.remote.BrowserWindow.getDevToolsExtensions was obsolete, this fix is trying to locate get/add/remove extension methods in [session] instead of BrowserWindow.