### PR TITLE
feat: raise event display limit to 20k

### DIFF
--- a/src/extension/background/index.ts
+++ b/src/extension/background/index.ts
@@ -7,7 +7,7 @@ import type {
   MessagePanel,
 } from '../../types/shared';
 
-const MAX_EVENTS = 1000;
+const MAX_EVENTS = 20000;
 const ipcEvents = new Denque<IpcEventDataIndexed>();
 
 const connections: {

--- a/src/extension/react/components/Panel.tsx
+++ b/src/extension/react/components/Panel.tsx
@@ -35,7 +35,7 @@ import { useDevtronContext } from '../context/context';
 const isDev = process.env.NODE_ENV === 'development';
 
 function Panel() {
-  const MAX_EVENTS_TO_DISPLAY = 1000;
+  const MAX_EVENTS_TO_DISPLAY = 20000;
 
   const [events, setEvents] = useState<IpcEventDataIndexed[]>([]);
   const [selectedRow, setSelectedRow] = useState<IpcEventDataIndexed | null>(null);


### PR DESCRIPTION
This PR increases the maximum number of visible rows from 1,000 to 20,000 to support a larger IPC event history.