### PR TITLE
feat: remove need to manually call `monitorRenderer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,19 @@
 - In your Electron app's `main.js` (or other relevant file) add the following code to load Devtron:
 
 ```js
+//main.js
+const { devtron } = require('@hitarth-gg/devtron');
+// or import { devtron } from '@hitarth-gg/devtron'
+
+devtron.install(); // call this function at the top of your file
+```
+
+or call `devtron.install()` inside the `app.whenReady()` callback like this:
+
+```js
 // main.js
-const { devtron } = require('@electron/devtron');
-// or import { devtron } from '@electron/devtron'
+const { devtron } = require('@hitarth-gg/devtron');
+// or import { devtron } from '@hitarth-gg/devtron'
 
 // function createWindow() {...}
 
@@ -26,16 +36,6 @@ app.whenReady().then(() => {
   devtron.install();
   // ...
 });
-```
-
-- In your Electron app's `preload.js` (or other relevant file) add the following code to load Devtron:
-
-```js
-// preload.js
-const { monitorRenderer } = require('@electron/devtron/monitorRenderer');
-// or import { monitorRenderer } from '@electron/devtron/monitorRenderer'
-
-monitorRenderer();
 ```
 
 If Devtron is installed correctly, it should appear as a tab in the Developer Tools of your Electron app.

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
       "require": "./dist/cjs/index.cjs",
       "types": "./dist/types/index.d.ts"
     },
-    "./monitorRenderer": {
-      "import": "./dist/mjs/electron-renderer-tracker.mjs",
-      "require": "./dist/cjs/electron-renderer-tracker.cjs",
-      "types": "./dist/types/lib/electron-renderer-tracker.d.ts"
-    },
     "./service-worker-preload": {
       "import": "./dist/mjs/service-worker-preload.mjs",
       "require": "./dist/cjs/service-worker-preload.cjs",
       "types": "./dist/types/lib/service-worker-preload.d.ts"
+    },
+    "./renderer-preload": {
+      "import": "./dist/mjs/renderer-preload.mjs",
+      "require": "./dist/cjs/renderer-preload.cjs",
+      "types": "./dist/types/lib/renderer-preload.d.ts"
     }
   },
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,16 +116,27 @@ async function install() {
     try {
       // register service worker preload script
       const dirname = __dirname; // __dirname is replaced with import.meta.url in ESM builds using webpack
-      const filePath = createRequire(dirname).resolve('@electron/devtron/service-worker-preload');
+      const serviceWorkerPreloadPath = createRequire(dirname).resolve(
+        '@electron/devtron/service-worker-preload',
+      );
+      const rendererPreloadPath = createRequire(dirname).resolve(
+        '@electron/devtron/renderer-preload',
+      );
 
       ses.registerPreloadScript({
-        filePath,
+        filePath: serviceWorkerPreloadPath,
         type: 'service-worker',
-        id: 'devtron-preload',
+        id: 'devtron-sw-preload',
+      });
+
+      ses.registerPreloadScript({
+        filePath: rendererPreloadPath,
+        type: 'frame',
+        id: 'devtron-renderer-preload',
       });
 
       // load extension
-      const extensionPath = path.resolve(filePath, '..', '..', 'extension');
+      const extensionPath = path.resolve(serviceWorkerPreloadPath, '..', '..', 'extension');
       devtron = await ses.extensions.loadExtension(extensionPath, { allowFileAccess: true });
       await startServiceWorker(ses, devtron);
       console.log('Devtron loaded successfully');

--- a/src/lib/renderer-preload.ts
+++ b/src/lib/renderer-preload.ts
@@ -1,0 +1,3 @@
+import { monitorRenderer } from './electron-renderer-tracker';
+
+monitorRenderer();

--- a/webpack.node.config.ts
+++ b/webpack.node.config.ts
@@ -3,7 +3,7 @@ import { DefinePlugin, type Configuration } from 'webpack';
 
 const entryPoints = {
   index: './src/index.ts',
-  'electron-renderer-tracker': './src/lib/electron-renderer-tracker.ts',
+  'renderer-preload': './src/lib/renderer-preload.ts',
   'service-worker-preload': './src/lib/service-worker-preload.ts',
 };
 


### PR DESCRIPTION
This PR:
- Removes the need to manually call `monitorRenderer` in preload files of an Electron app. Devtron now injects a preload script using `ses.registerPreloadScript` to track IPC events received by `ipcRenderer`.
- Allows Devtron to work correctly when `sandbox: true` is set in `webPreferences`.
- Updates the installation instructions in _README.md_.