### PR TITLE
feat: track response time of `invoke` and `sendSync` methods on `ipcRenderer` 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "denque": "^2.1.0",
         "lucide-react": "^0.513.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -10208,6 +10209,16 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11270,13 +11281,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "denque": "^2.1.0",
         "lucide-react": "^0.513.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "uuid": "^11.1.0"
+        "react-dom": "^19.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -11278,19 +11277,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -84,8 +84,7 @@
     "denque": "^2.1.0",
     "lucide-react": "^0.513.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "uuid": "^11.1.0"
+    "react-dom": "^19.1.0"
   },
   "files": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "denque": "^2.1.0",
     "lucide-react": "^0.513.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "uuid": "^11.1.0"
   },
   "files": [
     "dist/",

--- a/src/extension/react/components/DetailPanel.tsx
+++ b/src/extension/react/components/DetailPanel.tsx
@@ -10,8 +10,9 @@ type Props = {
   selectedRow: IpcEventDataIndexed | null;
   onClose: () => void;
   direction?: 'right' | 'bottom';
+  gotoRow?: (row: number) => void;
 };
-function DetailPanel({ selectedRow, onClose, direction = 'right' }: Props) {
+function DetailPanel({ selectedRow, onClose, direction = 'right', gotoRow }: Props) {
   const { theme } = useDevtronContext();
   if (!selectedRow) return null;
 
@@ -99,6 +100,21 @@ function DetailPanel({ selectedRow, onClose, direction = 'right' }: Props) {
                 <span className="text-nowrap font-medium">Response Time: </span>
                 <span className="block max-w-96 break-all rounded bg-gray-200 px-1 py-0.5 dark:bg-charcoal-500">
                   {selectedRow.responseTime.toFixed(2)} ms
+                </span>
+              </div>
+            )}
+
+            {/* Linked Event */}
+            {selectedRow.gotoSerialNumber && (
+              <div className="flex w-fit items-center gap-x-1">
+                <span className="text-nowrap font-medium">Linked Event: </span>
+                <span
+                  className="block max-w-96 cursor-pointer break-all rounded bg-gray-200 px-1 py-0.5 text-cyan-700 hover:underline dark:bg-charcoal-500 dark:text-cyan-500"
+                  onClick={() => {
+                    if (gotoRow) gotoRow(selectedRow.gotoSerialNumber!);
+                  }}
+                >
+                  #{selectedRow.gotoSerialNumber}
                 </span>
               </div>
             )}

--- a/src/extension/react/components/DetailPanel.tsx
+++ b/src/extension/react/components/DetailPanel.tsx
@@ -92,6 +92,16 @@ function DetailPanel({ selectedRow, onClose, direction = 'right' }: Props) {
                 </span>
               </div>
             )}
+
+            {/* Response Time */}
+            {selectedRow.responseTime && (
+              <div className="flex w-fit items-center gap-x-1">
+                <span className="text-nowrap font-medium">Response Time: </span>
+                <span className="block max-w-96 break-all rounded bg-gray-200 px-1 py-0.5 dark:bg-charcoal-500">
+                  {selectedRow.responseTime.toFixed(2)} ms
+                </span>
+              </div>
+            )}
           </div>
 
           {/* Args */}

--- a/src/extension/react/components/DirectionBadge.tsx
+++ b/src/extension/react/components/DirectionBadge.tsx
@@ -53,6 +53,14 @@ export default function DirectionBadge({ direction }: Props) {
           labelRight: '',
           tooltip: 'Renderer',
         };
+      case 'main':
+        return {
+          colorClass:
+            'dark:bg-dark-purple dark:text-light-purple bg-purple-100 text-purple-800 border-purple-300 dark:border-light-purple',
+          labelLeft: 'Main',
+          labelRight: '',
+          tooltip: 'Main',
+        };
       default:
         return {
           colorClass:

--- a/src/extension/react/components/Panel.tsx
+++ b/src/extension/react/components/Panel.tsx
@@ -167,8 +167,17 @@ function Panel() {
         flex: 1,
         cellClass: 'font-roboto text-[13px] !p-1 h-full flex items-center',
         headerClass: '!h-6',
-        tooltipValueGetter: (params) => {
-          return params.value; // or a custom string
+        cellRenderer: (params: ICellRendererParams<IpcEventDataIndexed>) => {
+          return (
+            <div className="" title={params.value}>
+              {params.value}
+              {params.data?.responseTime && (
+                <span className="ml-2 rounded bg-gray-200 px-1.5 py-0.5 text-xs dark:bg-charcoal-400">
+                  Response
+                </span>
+              )}
+            </div>
+          );
         },
       },
       {

--- a/src/extension/react/components/Panel.tsx
+++ b/src/extension/react/components/Panel.tsx
@@ -57,7 +57,7 @@ function Panel() {
   } = useDevtronContext();
 
   /**
-   * uuidMapRef stores the indexes of events that have a UUID.
+   * uuidMapRef stores the serial numbers of events that have a UUID.
    * If an event with the same UUID is received later on, we add a gotoSerialNumber property
    * to the previous event with the same UUID.
    * This allows us to jump between events that are related to each other.
@@ -172,7 +172,7 @@ function Panel() {
 
             uuidMapRef.current.delete(event.uuid);
           } else if (event.uuid) {
-            // If a UUID is encountered for the first time, we store its index
+            // If a UUID is encountered for the first time, we store its serialNumber
             uuidMapRef.current.set(event.uuid, event.serialNumber);
           }
 

--- a/src/extension/react/components/Panel.tsx
+++ b/src/extension/react/components/Panel.tsx
@@ -219,7 +219,7 @@ function Panel() {
         headerClass: '!h-6',
         cellRenderer: (params: ICellRendererParams<IpcEventDataIndexed>) => {
           return (
-            <div className="" title={params.value}>
+            <div title={params.value}>
               {params.value}
               {params.data?.responseTime && (
                 <span className="ml-2 rounded bg-gray-200 px-1.5 py-0.5 text-xs dark:bg-charcoal-400">

--- a/src/extension/react/test_data/test_data.ts
+++ b/src/extension/react/test_data/test_data.ts
@@ -103,4 +103,13 @@ export const events: IpcEventDataIndexed[] = [
       serviceWorkerVersionId: 32,
     },
   },
+  {
+    serialNumber: 130,
+    direction: 'main-to-renderer',
+    method: 'sendSync (response)',
+    channel: 'sendSync-check',
+    args: ['sync response data'],
+    timestamp: 1749114387250,
+    responseTime: 2000.34,
+  },
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,33 @@ type Listener = any;
 let isInstalled = false;
 let isInstalledToDefaultSession = false;
 let devtronSW: Electron.ServiceWorkerMain;
+
+const isPayloadWithUuid = (payload: any[]): boolean => {
+  // If the first argument is an object with __uuid__devtron then it is a custom payload
+  return (
+    payload[0] &&
+    typeof payload[0] === 'object' &&
+    payload[0].__uuid__devtron &&
+    Array.isArray(payload[0].args)
+  );
+};
+
+const getArgsFromPayload = (payload: any[]): any[] => {
+  if (isPayloadWithUuid(payload)) {
+    // If the payload is a custom payload, return the args array
+    return payload[0].args || [];
+  }
+  // Otherwise, return the payload as is
+  return payload;
+};
+
+const getUuidFromPayload = (payload: any[]): string => {
+  if (isPayloadWithUuid(payload)) {
+    return payload[0].__uuid__devtron;
+  }
+  return '';
+};
+
 /**
  * sends captured IPC events to the service-worker preload script
  */
@@ -29,14 +56,8 @@ function trackIpcEvent({
   serviceWorkerDetails,
   method,
 }: TrackIpcEventOptions) {
-  let uuid = '';
-  let newArgs = args;
-
-  // extract the UUID if it exists
-  if (args[0] && typeof args[0] === 'object' && args[0].__uuid__devtron) {
-    uuid = args[0].__uuid__devtron;
-    newArgs = args[0].args;
-  }
+  const uuid = getUuidFromPayload(args);
+  const newArgs = getArgsFromPayload(args);
 
   const eventData: IpcEventData = {
     direction,
@@ -213,15 +234,6 @@ function patchIpcMain() {
       listenerMap.set(channel, new Map());
     }
     listenerMap.get(channel)!.set(original, tracked);
-  };
-
-  const getArgsFromPayload = (payload: any[]): any[] => {
-    if (payload[0] && typeof payload[0] === 'object' && payload[0].__uuid__devtron) {
-      // If the first argument is an object with __uuid__devtron, return its args property
-      return payload[0].args || [];
-    }
-    // Otherwise, return the payload as is
-    return payload;
   };
 
   const originalOn = ipcMain.on.bind(ipcMain);

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ function trackIpcEvent({
   if (method) eventData.method = method;
   if (uuid) eventData.uuid = uuid;
 
-  if (devtronSW === null) {
+  if (!devtronSW) {
     console.error('The service-worker for Devtron is not registered yet. Cannot track IPC event.');
     return;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,48 @@
-import { app, session } from 'electron';
+import { app, ipcMain, session } from 'electron';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import type { Direction, IpcEventData, ServiceWorkerDetails } from './types/shared';
 
+interface TrackIpcEventOptions {
+  direction: Direction;
+  channel: string;
+  args: any[];
+  devtronSW: Electron.ServiceWorkerMain;
+  serviceWorkerDetails?: ServiceWorkerDetails;
+  method?: string;
+}
+
 let isInstalled = false;
 let isInstalledToDefaultSession = false;
-
+let devtronSW: Electron.ServiceWorkerMain;
 /**
  * sends captured IPC events to the service-worker preload script
  */
-function trackIpcEvent(
-  direction: Direction,
-  channel: string,
-  args: any[],
-  devtronSW: Electron.ServiceWorkerMain,
-  serviceWorkerDetails?: ServiceWorkerDetails,
-) {
+function trackIpcEvent({
+  direction,
+  channel,
+  args,
+  devtronSW,
+  serviceWorkerDetails,
+  method,
+}: TrackIpcEventOptions) {
+  let uuid = '';
+  let newArgs = args;
+  // extract the UUID if it exists
+  if (args[0] && typeof args[0] === 'object' && args[0].__uuid__devtron) {
+    uuid = args[0].__uuid__devtron;
+    newArgs = args[0].args;
+  }
+
   const eventData: IpcEventData = {
     direction,
     channel,
-    args,
+    args: newArgs,
     timestamp: Date.now(),
     serviceWorkerDetails,
   };
+  if (method) eventData.method = method;
+  if (uuid) eventData.uuid = uuid;
 
   if (devtronSW === null) {
     console.error('The service-worker for Devtron is not registered yet. Cannot track IPC event.');
@@ -40,9 +60,10 @@ function registerIpcListeners(ses: Electron.Session, devtronSW: Electron.Service
       channel: string,
       args: any[],
     ) => {
-      if (event.type === 'frame') trackIpcEvent('renderer-to-main', channel, args, devtronSW);
+      if (event.type === 'frame')
+        trackIpcEvent({ direction: 'renderer-to-main', channel, args, devtronSW });
       else if (event.type === 'service-worker')
-        trackIpcEvent('service-worker-to-main', channel, args, devtronSW);
+        trackIpcEvent({ direction: 'service-worker-to-main', channel, args, devtronSW });
     },
   );
 
@@ -54,9 +75,10 @@ function registerIpcListeners(ses: Electron.Session, devtronSW: Electron.Service
       channel: string,
       args: any[],
     ) => {
-      if (event.type === 'frame') trackIpcEvent('renderer-to-main', channel, args, devtronSW);
+      if (event.type === 'frame')
+        trackIpcEvent({ direction: 'renderer-to-main', channel, args, devtronSW });
       else if (event.type === 'service-worker')
-        trackIpcEvent('service-worker-to-main', channel, args, devtronSW);
+        trackIpcEvent({ direction: 'service-worker-to-main', channel, args, devtronSW });
     },
   );
   ses.on(
@@ -67,9 +89,10 @@ function registerIpcListeners(ses: Electron.Session, devtronSW: Electron.Service
       channel: string,
       args: any[],
     ) => {
-      if (event.type === 'frame') trackIpcEvent('renderer-to-main', channel, args, devtronSW);
+      if (event.type === 'frame')
+        trackIpcEvent({ direction: 'renderer-to-main', channel, args, devtronSW });
       else if (event.type === 'service-worker')
-        trackIpcEvent('service-worker-to-main', channel, args, devtronSW);
+        trackIpcEvent({ direction: 'service-worker-to-main', channel, args, devtronSW });
     },
   );
 }
@@ -96,16 +119,16 @@ function registerServiceWorkerSendListener(
 
     const originalSend = sw.send;
     sw.send = function (...args) {
-      trackIpcEvent(
-        'main-to-service-worker',
-        args[0], // channel
-        args.slice(1), // args
+      trackIpcEvent({
+        direction: 'main-to-service-worker',
+        channel: args[0],
+        args: args.slice(1),
         devtronSW,
-        {
+        serviceWorkerDetails: {
           serviceWorkerScope: sw.scope,
           serviceWorkerVersionId: sw.versionId,
         },
-      );
+      });
       return originalSend.apply(this, args);
     };
   }
@@ -126,16 +149,16 @@ function registerServiceWorkerSendListener(
 
       const originalSend = sw.send;
       sw.send = function (...args) {
-        trackIpcEvent(
-          'main-to-service-worker',
-          args[0], // channel
-          args.slice(1), // args
+        trackIpcEvent({
+          direction: 'main-to-service-worker',
+          channel: args[0],
+          args: args.slice(1),
           devtronSW,
-          {
+          serviceWorkerDetails: {
             serviceWorkerScope: sw.scope,
             serviceWorkerVersionId: sw.versionId,
           },
-        );
+        });
         return originalSend.apply(this, args);
       };
     }
@@ -146,6 +169,7 @@ async function startServiceWorker(ses: Electron.Session, extension: Electron.Ext
   try {
     const sw = await ses.serviceWorkers.startWorkerForScope(extension.url);
     sw.startTask();
+    devtronSW = sw;
     registerIpcListeners(ses, sw);
     registerServiceWorkerSendListener(ses, sw);
   } catch (error) {
@@ -163,6 +187,7 @@ async function startServiceWorker(ses: Electron.Session, extension: Electron.Ext
         if (details.scope === extension.url) {
           const sw = await ses.serviceWorkers.startWorkerForScope(extension.url);
           sw.startTask();
+          devtronSW = sw;
           registerIpcListeners(ses, sw);
           registerServiceWorkerSendListener(ses, sw);
           ses.serviceWorkers.removeListener('registration-completed', handleDetails);
@@ -176,9 +201,168 @@ async function startServiceWorker(ses: Electron.Session, extension: Electron.Ext
   }
 }
 
+function patchIpcMain() {
+  const listenerMap = new Map<string, Map<any, any>>(); // channel -> (originalListener -> tracked/cleaned Listener)
+
+  const storeTrackedListener = (channel: string, original: any, tracked: any): void => {
+    if (!listenerMap.has(channel)) {
+      listenerMap.set(channel, new Map());
+    }
+    listenerMap.get(channel)!.set(original, tracked);
+  };
+
+  const getArgsFromPayload = (payload: any[]): any[] => {
+    if (payload[0] && typeof payload[0] === 'object' && payload[0].__uuid__devtron) {
+      // If the first argument is an object with __uuid__devtron, return its args property
+      return payload[0].args || [];
+    }
+    // Otherwise, return the payload as is
+    return payload;
+  };
+
+  const originalOn = ipcMain.on.bind(ipcMain);
+  const originalOff = ipcMain.off.bind(ipcMain);
+  const originalOnce = ipcMain.once.bind(ipcMain);
+  const originalAddListener = ipcMain.addListener.bind(ipcMain);
+  const originalRemoveListener = ipcMain.removeListener.bind(ipcMain);
+  const originalRemoveAllListeners = ipcMain.removeAllListeners.bind(ipcMain);
+  const originalHandle = ipcMain.handle.bind(ipcMain);
+  const originalHandleOnce = ipcMain.handleOnce.bind(ipcMain);
+  const originalRemoveHandler = ipcMain.removeHandler.bind(ipcMain);
+
+  ipcMain.on = (
+    channel: string,
+    listener: (event: Electron.IpcMainEvent, ...args: any[]) => void,
+  ) => {
+    const cleanedListener = (event: Electron.IpcMainEvent, ...args: any[]) => {
+      const newArgs = getArgsFromPayload(args);
+      listener(event, ...newArgs);
+    };
+    storeTrackedListener(channel, listener, cleanedListener);
+    return originalOn(channel, cleanedListener);
+  };
+
+  ipcMain.off = (
+    channel: string,
+    listener: (event: Electron.IpcMainEvent, ...args: any[]) => void,
+  ) => {
+    const channelMap = listenerMap.get(channel);
+    const cleanedListener = channelMap?.get(listener);
+
+    if (!cleanedListener) return ipcMain;
+
+    channelMap?.delete(listener);
+    if (channelMap && channelMap.size === 0) {
+      listenerMap.delete(channel);
+    }
+
+    trackIpcEvent({ direction: 'main', channel, args: [], devtronSW, method: 'off' });
+    return originalOff(channel, cleanedListener);
+  };
+
+  ipcMain.once = (
+    channel: string,
+    listener: (event: Electron.IpcMainEvent, ...args: any[]) => void,
+  ) => {
+    const cleanedListener = (event: Electron.IpcMainEvent, ...args: any[]) => {
+      const newArgs = getArgsFromPayload(args);
+      listener(event, ...newArgs);
+    };
+    return originalOnce(channel, cleanedListener);
+  };
+
+  ipcMain.addListener = (
+    channel: string,
+    listener: (event: Electron.IpcMainEvent, ...args: any[]) => void,
+  ) => {
+    const cleanedListener = (event: Electron.IpcMainEvent, ...args: any[]) => {
+      const newArgs = getArgsFromPayload(args);
+      listener(event, ...newArgs);
+    };
+    storeTrackedListener(channel, listener, cleanedListener);
+    return originalAddListener(channel, cleanedListener);
+  };
+
+  ipcMain.removeListener = (
+    channel: string,
+    listener: (event: Electron.IpcMainEvent, ...args: any[]) => void,
+  ) => {
+    const channelMap = listenerMap.get(channel);
+    const cleanedListener = channelMap?.get(listener);
+
+    if (!cleanedListener) return ipcMain;
+
+    // Remove the listener from the map
+    channelMap?.delete(listener);
+    // If no listeners left for this channel, remove the channel from the map
+    if (channelMap && channelMap.size === 0) {
+      listenerMap.delete(channel);
+    }
+    trackIpcEvent({ direction: 'main', channel, args: [], devtronSW, method: 'removeListener' });
+    return originalRemoveListener(channel, cleanedListener);
+  };
+
+  ipcMain.removeAllListeners = (channel?: string) => {
+    if (channel) {
+      listenerMap.delete(channel);
+      trackIpcEvent({
+        direction: 'main',
+        channel,
+        args: [],
+        devtronSW,
+        method: 'removeAllListeners',
+      });
+      return originalRemoveAllListeners(channel);
+    } else {
+      listenerMap.clear();
+      trackIpcEvent({
+        direction: 'main',
+        channel: '',
+        args: [],
+        devtronSW,
+        method: 'removeAllListeners',
+      });
+      listenerMap.clear();
+      return originalRemoveAllListeners();
+    }
+  };
+
+  ipcMain.handle = (
+    channel: string,
+    listener: (event: Electron.IpcMainInvokeEvent, ...args: any[]) => Promise<any> | any,
+  ) => {
+    const cleanedListener = async (event: Electron.IpcMainInvokeEvent, ...args: any[]) => {
+      const newArgs = getArgsFromPayload(args);
+      const result = await listener(event, ...newArgs);
+      return result;
+    };
+    return originalHandle(channel, cleanedListener);
+  };
+
+  ipcMain.handleOnce = (
+    channel: string,
+    listener: (event: Electron.IpcMainInvokeEvent, ...args: any[]) => Promise<any> | any,
+  ) => {
+    const cleanedListener = async (event: Electron.IpcMainInvokeEvent, ...args: any[]) => {
+      const newArgs = getArgsFromPayload(args);
+      const result = await listener(event, ...newArgs);
+      return result;
+    };
+    return originalHandleOnce(channel, cleanedListener);
+  };
+
+  ipcMain.removeHandler = (channel: string) => {
+    listenerMap.delete(channel);
+    trackIpcEvent({ direction: 'main', channel, args: [], devtronSW, method: 'removeHandler' });
+    return originalRemoveHandler(channel);
+  };
+}
+
 async function install() {
   if (isInstalled) return;
   isInstalled = true;
+
+  patchIpcMain();
 
   const installToSession = async (ses: Electron.Session) => {
     if (ses === session.defaultSession && isInstalledToDefaultSession) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,9 @@ interface TrackIpcEventOptions {
   method?: string;
 }
 
+type Channel = string;
+type Listener = any;
+
 let isInstalled = false;
 let isInstalledToDefaultSession = false;
 let devtronSW: Electron.ServiceWorkerMain;
@@ -28,6 +31,7 @@ function trackIpcEvent({
 }: TrackIpcEventOptions) {
   let uuid = '';
   let newArgs = args;
+
   // extract the UUID if it exists
   if (args[0] && typeof args[0] === 'object' && args[0].__uuid__devtron) {
     uuid = args[0].__uuid__devtron;
@@ -202,7 +206,7 @@ async function startServiceWorker(ses: Electron.Session, extension: Electron.Ext
 }
 
 function patchIpcMain() {
-  const listenerMap = new Map<string, Map<any, any>>(); // channel -> (originalListener -> tracked/cleaned Listener)
+  const listenerMap = new Map<Channel, Map<Listener, Listener>>(); // channel -> (originalListener -> tracked/cleaned Listener)
 
   const storeTrackedListener = (channel: string, original: any, tracked: any): void => {
     if (!listenerMap.has(channel)) {

--- a/src/lib/electron-renderer-tracker.ts
+++ b/src/lib/electron-renderer-tracker.ts
@@ -1,6 +1,8 @@
 import { ipcRenderer } from 'electron';
 import { MSG_TYPE } from '../common/constants';
 import type { Direction, IpcEventData } from '../types/shared';
+import { performance } from 'node:perf_hooks';
+import { v4 as uuidv4 } from 'uuid';
 
 interface PanelMessage {
   source: typeof MSG_TYPE.SEND_TO_PANEL;
@@ -133,21 +135,31 @@ export function monitorRenderer(): void {
   };
 
   ipcRenderer.sendSync = function (channel: string, ...args: any[]) {
+    const uuid = uuidv4(); // uuid is used to match the response with the request
+    const payload = {
+      __uuid__devtron: uuid,
+      args,
+    };
     const start = performance.now();
-    const result = originalSendSync(channel, ...args);
+    const result = originalSendSync(channel, payload);
     const duration = performance.now() - start;
 
-    track('main-to-renderer', channel, [result], 'sendSync (response)', duration);
+    track('main-to-renderer', channel, [result], 'sendSync (response)', duration, uuid);
 
     return result;
   };
 
   ipcRenderer.invoke = async function (channel: string, ...args: any[]): Promise<any> {
+    const uuid = uuidv4(); // uuid is used to match the response with the request
+    const payload = {
+      __uuid__devtron: uuid,
+      args,
+    };
     const start = performance.now();
-    const result = await originalInvoke(channel, ...args);
+    const result = await originalInvoke(channel, payload);
     const duration = performance.now() - start;
 
-    track('main-to-renderer', channel, [result], 'invoke (response)', duration);
+    track('main-to-renderer', channel, [result], 'invoke (response)', duration, uuid);
 
     return result;
   };
@@ -159,12 +171,14 @@ function track(
   args: any[],
   method?: string,
   responseTime?: number,
+  uuid?: string,
 ): void {
   const event: IpcEventData = {
     timestamp: Date.now(),
     direction,
     channel,
     args: copyArgs(args),
+    uuid,
   };
   if (method) event.method = method;
   if (responseTime) event.responseTime = responseTime;

--- a/src/lib/electron-renderer-tracker.ts
+++ b/src/lib/electron-renderer-tracker.ts
@@ -1,8 +1,6 @@
 import { ipcRenderer } from 'electron';
 import { MSG_TYPE } from '../common/constants';
 import type { Direction, IpcEventData } from '../types/shared';
-import { performance } from 'node:perf_hooks';
-import { v4 as uuidv4 } from 'uuid';
 
 interface PanelMessage {
   source: typeof MSG_TYPE.SEND_TO_PANEL;
@@ -135,7 +133,7 @@ export function monitorRenderer(): void {
   };
 
   ipcRenderer.sendSync = function (channel: string, ...args: any[]) {
-    const uuid = uuidv4(); // uuid is used to match the response with the request
+    const uuid = crypto.randomUUID(); // uuid is used to match the response with the request
     const payload = {
       __uuid__devtron: uuid,
       args,
@@ -150,7 +148,7 @@ export function monitorRenderer(): void {
   };
 
   ipcRenderer.invoke = async function (channel: string, ...args: any[]): Promise<any> {
-    const uuid = uuidv4(); // uuid is used to match the response with the request
+    const uuid = crypto.randomUUID(); // uuid is used to match the response with the request
     const payload = {
       __uuid__devtron: uuid,
       args,

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -6,7 +6,6 @@ export type Direction =
   | 'service-worker-to-main'
   | 'main-to-service-worker'
   | 'renderer'
-  | 'renderer'
   | 'main';
 
 export type ServiceWorkerDetails = {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -19,6 +19,7 @@ export interface IpcEventData {
   timestamp: number;
   method?: string;
   serviceWorkerDetails?: ServiceWorkerDetails;
+  responseTime?: number; // To track response time for `sendSync` and `invoke` methods
 }
 
 /* ------------------------------------------------------ */

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -5,7 +5,9 @@ export type Direction =
   | 'main-to-renderer'
   | 'service-worker-to-main'
   | 'main-to-service-worker'
-  | 'renderer';
+  | 'renderer'
+  | 'renderer'
+  | 'main';
 
 export type ServiceWorkerDetails = {
   serviceWorkerVersionId: number;
@@ -20,6 +22,7 @@ export interface IpcEventData {
   method?: string;
   serviceWorkerDetails?: ServiceWorkerDetails;
   responseTime?: number; // To track response time for `sendSync` and `invoke` methods
+  uuid?: string; // UUID to match requests and responses (for `invoke` and `sendSync` methods on `ipcRenderer`)
 }
 
 /* ------------------------------------------------------ */
@@ -27,6 +30,7 @@ export interface IpcEventData {
 /* ---------------------- EXTENSION --------------------- */
 export interface IpcEventDataIndexed extends IpcEventData {
   serialNumber: number;
+  gotoSerialNumber?: number; // For navigating to a specific event in the grid
 }
 
 export type MessagePanel =


### PR DESCRIPTION
#### Description of Change
- Allows Devtron to track the time (in milliseconds) it takes for `ipcRenderer.invoke` and `ipcRenderer.sendSync` to receive responses back from the main process.
- Patches `.on`, `.off`, `.once`, `.addListener`, `.removeListener`, `.removeAllListeners`, `.handle`, `.handleOnce`, and `.removeHandler` methods of `ipcMain` to allow Devtron to track response times and detect when handlers or listeners are **removed** from `ipcMain`.

#### Tracking `.sendSync` and `.invoke` response times:
| Request | Response |
| ------------- | ------------- |
| <img width="1142" height="579" alt="image" src="https://github.com/user-attachments/assets/9e4bb1ba-843a-479b-9433-702e2bc6424f" />  |  <img width="1142" height="579" alt="image" src="https://github.com/user-attachments/assets/d6bbbd0f-fdfe-4ac0-b2a4-f16850fc3d8a" /> |

- Clicking on the `Linked Event` field in the Details Panel will redirect the user to the linked event.
- Internally, the two events are linked using a UUID. Renderer process generates a UUID and includes it in the arguments of `.sendSync` and `.invoke` requests. This UUID is then received by the main process, where it is extracted from the arguments. As a result, both processes use the same UUID to track the events. Events with matching UUIDs are then linked together in the frontend.

#### Tracking `.once` and `.handleOnce`:
<img width="1142" height="307" alt="image" src="https://github.com/user-attachments/assets/ce95a872-35e7-4c19-bcf5-948900515f7d" />

- `ipcMain.once` is tracked as two separate events: `ipcMain.removeListener` and `ipcMain.on`. 
- `ipcMain.handleOnce` is tracked as two separate events: `ipcMain.removeHandler` and `ipcMain.handle`.

