### PR TITLE
fix: type declarations not found and invalid `require` usage in ESM build

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const { devtron } = require('@electron/devtron');
 devtron.install(); // call this function at the top of your file
 ```
 
-Devtron can be conditionally installed in **development mode** to avoid impacting production builds. Here's an example:
+- Devtron can be conditionally installed in **development mode** to avoid impacting production builds. Here's an example:
 
 ```js
 const isDev = true

--- a/README.md
+++ b/README.md
@@ -23,6 +23,30 @@ const { devtron } = require('@electron/devtron');
 devtron.install(); // call this function at the top of your file
 ```
 
+Devtron can be conditionally installed in **development mode** to avoid impacting production builds. Here's an example:
+
+```js
+const isDev = true
+
+async function installDevtron() {
+  const { devtron } = await import('@electron/devtron')
+  await devtron.install()
+}
+
+if (isDev) {
+  installDevtron().catch((error) => {
+    console.error('Failed to install Devtron:', error)
+  })
+}
+```
+
+## Requirements and Limitations
+
+- Electron version must be 36.0.0 or higher.
+- For Devtron to work with newly created **sessions**, you must call `devtron.install()` before they are created.
+- IPC events sent before Devtron is installed (during early app startup) might not be captured.
+- `ipcRenderer.once` will be tracked as two separate events `ipcRenderer.on` and then `ipcRenderer.removeListener`.
+
 If Devtron is installed correctly, it should appear as a tab in the Developer Tools of your Electron app.
 
 <img src="https://github.com/user-attachments/assets/0f278b54-50fe-4116-9317-9c1525bf872b" width="800">

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@electron/devtron",
   "version": "0.0.0-development",
   "description": "Electron DevTools Extension to track IPC events",
+  "main": "./dist/cjs/index.cjs",
+  "module": "./dist/mjs/index.mjs",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/mjs/index.mjs",

--- a/webpack.node.config.ts
+++ b/webpack.node.config.ts
@@ -30,9 +30,6 @@ const commonConfig: Configuration = {
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx'],
   },
-  externals: {
-    electron: 'commonjs2 electron',
-  },
 };
 
 const esmConfig: Configuration = {
@@ -54,6 +51,9 @@ const esmConfig: Configuration = {
       __dirname: 'import.meta.url',
     }),
   ],
+  externals: {
+    electron: 'module electron',
+  },
 };
 
 const cjsConfig: Configuration = {
@@ -67,6 +67,9 @@ const cjsConfig: Configuration = {
   },
   target: 'node',
   mode: 'none',
+  externals: {
+    electron: 'commonjs2 electron',
+  },
 };
 
 const config: Configuration[] = [esmConfig, cjsConfig];


### PR DESCRIPTION
This PR:
- Fixes an issue where type declarations could not be found when using `moduleResolution: "Node"` in `tsconfig` by adding `main`, `module` and `types` filed in `package.json`.
  - It is related to: https://github.com/electron-userland/devtron/issues/272#issuecomment-3134031245
- Adds documentation on conditionally installing Devtron using `await import`, along with known limitations and requirements.
- Fixes an issue where the ESM build used `require`, causing errors when loading Devtron via `await import` in CJS environment.