### PR TITLE
feat: default to system color scheme in UI

### DIFF
--- a/src/extension/react/context/context.tsx
+++ b/src/extension/react/context/context.tsx
@@ -52,6 +52,11 @@ export default function DevtronProvider({ children }: DevtronProviderProps) {
     const savedTheme = localStorage.getItem('theme') as Theme | null;
     if (savedTheme) {
       setTheme(savedTheme);
+    } else {
+      // set theme based on system preference if not set
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const initialTheme: Theme = prefersDark ? 'dark' : 'light';
+      setTheme(initialTheme);
     }
 
     const savedDetailPanelPosition = localStorage.getItem(


### PR DESCRIPTION
This PR:
- Updates Devtron to use the system's color scheme (light or dark) by default.